### PR TITLE
docs: add release notes for v2.1.0

### DIFF
--- a/releases/2.1.0.md
+++ b/releases/2.1.0.md
@@ -1,0 +1,223 @@
+# Release 2.1.0
+
+**Release Date:** December 1, 2025
+**Type:** Minor Release
+**GitHub Release:** https://github.com/axeptio/axeptio-ios-sdk/releases/tag/2.1.0
+
+## Overview
+
+Version 2.1.0 introduces flexible widget environment configuration, enhanced consent duration management, and improved developer tooling. This release enables developers to test against staging and PR environments, provides fine-grained control over consent cookie lifetimes, and automatically handles non-persistent consent scopes.
+
+## What's New
+
+### Widget Environment Configuration
+
+Select between production, staging, and PR-specific widget environments to support your development workflow.
+
+**New Features:**
+
+- `WidgetType` enum with three options: `.production`, `.staging`, `.pr`
+- Unified initialization API with widget type parameter
+- Support for PR-specific widget deployments via `widgetPR` parameter
+
+**Usage Example:**
+
+```swift
+// Production environment (default)
+Axeptio.shared.initialize(
+    targetService: .publisherTcf,
+    clientId: "your-client-id",
+    cookiesVersion: "your-version",
+    widgetType: .production
+)
+
+// Staging environment for testing
+Axeptio.shared.initialize(
+    targetService: .publisherTcf,
+    clientId: "your-client-id",
+    cookiesVersion: "your-version",
+    widgetType: .staging
+)
+
+// PR environment for testing specific changes
+Axeptio.shared.initialize(
+    targetService: .publisherTcf,
+    clientId: "your-client-id",
+    cookiesVersion: "your-version",
+    widgetType: .pr,
+    widgetPR: "123"
+)
+```
+
+### Consent Duration Management
+
+Take control of consent cookie lifetimes with configurable duration and update policies.
+
+**New Features:**
+
+- `cookiesDurationDays` parameter (default: 190 days)
+- `shouldUpdateCookiesDuration` flag to control duration updates
+- `getRemainingDaysForConsent()` method to check consent expiration
+
+**Usage Example:**
+
+```swift
+// Custom consent duration
+Axeptio.shared.initialize(
+    targetService: .publisherTcf,
+    clientId: "your-client-id",
+    cookiesVersion: "your-version",
+    cookiesDurationDays: 365,
+    shouldUpdateCookiesDuration: true
+)
+
+// Check remaining days
+if let remainingDays = Axeptio.shared.getRemainingDaysForConsent() {
+    print("Consent expires in \(remainingDays) days")
+}
+```
+
+### Non-Persistent Scope Support
+
+Automatic widget refresh for session-based and page-based consent flows.
+
+**New Features:**
+
+- Automatic detection of non-persistent consent scopes
+- Widget refresh on app resume for session/page scopes
+- New `ConsentScope` enum: `.session`, `.page`, `.persistent`
+
+**Behavior:**
+When your widget is configured with a non-persistent scope (session or page), the SDK now automatically refreshes the consent widget when appropriate, ensuring users see the consent dialog according to your configuration.
+
+### Enhanced Consent Inspection
+
+New data models and APIs for detailed consent inspection.
+
+**New Types:**
+
+- `ConsentResponse`: Complete consent response data
+- `WidgetParamsStatus`: Widget parameter status information
+- `ConsentScope`: Consent persistence scope
+
+### Developer Experience Improvements
+
+**Sample App Enhancements:**
+
+- New configuration screen for easy SDK setup
+- Client ID, cookies version, and token configuration
+- Widget type and PR selection
+- Target service selection
+
+**Debugging Tools:**
+
+- Vendor consent debugging view
+- Improved navigation and UI
+- Enhanced testing capabilities
+
+## Migration Guide
+
+### Updating Your Integration
+
+Version 2.1.0 consolidates the initialization API into a single method. Update your initialization code as follows:
+
+**Before (2.0.x):**
+
+```swift
+Axeptio.shared.initialize(
+    targetService: .publisherTcf,
+    clientId: "your-client-id",
+    cookiesVersion: "your-version"
+)
+```
+
+**After (2.1.0):**
+
+```swift
+Axeptio.shared.initialize(
+    targetService: .publisherTcf,
+    clientId: "your-client-id",
+    cookiesVersion: "your-version",
+    widgetType: .production  // Explicitly specify environment
+)
+```
+
+### API Changes
+
+**Breaking Changes:**
+
+- Previous `initialize()` method overloads have been replaced with a single unified method
+- The `token` parameter is now optional
+- You must specify a `widgetType` (use `.production` for existing production apps)
+
+**Deprecations:**
+
+- None
+
+**New APIs:**
+
+- `getRemainingDaysForConsent() -> Int?`: Check consent expiration
+- New initialization parameters: `widgetType`, `widgetPR`, `cookiesDurationDays`, `shouldUpdateCookiesDuration`
+
+### Testing Your Migration
+
+1. Update your initialization call to include `widgetType: .production`
+2. Test your integration in production mode
+3. (Optional) Test staging environment before releasing
+4. Verify consent behavior matches expectations
+
+## Installation
+
+### Swift Package Manager
+
+Add the following to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/axeptio/axeptio-ios-sdk", from: "2.1.0")
+]
+```
+
+Or add via Xcode:
+
+1. File > Add Package Dependencies
+2. Enter: `https://github.com/axeptio/axeptio-ios-sdk`
+3. Select version: 2.1.0
+
+### CocoaPods
+
+Add to your `Podfile`:
+
+```ruby
+pod 'AxeptioIOSSDK', '~> 2.1.0'
+```
+
+Then run:
+
+```bash
+pod install
+```
+
+## Related Resources
+
+- **Documentation:** [README.md](../README.md)
+- **Sample App:** [sample-app-ios](https://github.com/axeptio/sample-app-ios)
+- **GitHub Release:** [v2.1.0](https://github.com/axeptio/axeptio-ios-sdk/releases/tag/2.1.0)
+- **Issues:** [GitHub Issues](https://github.com/axeptio/axeptio-ios-sdk-sources/issues)
+- **Changelog:** [CHANGELOG.md](../CHANGELOG.md)
+
+## Technical Details
+
+**Commits:** 34 commits from develop branch
+**Changes:** +2516 additions, -280 deletions
+**Pull Request:** [#65](https://github.com/axeptio/axeptio-ios-sdk-sources/pull/65)
+
+**Related Issues:**
+
+- MSK-120: Widget environment selection
+- MSK-118: Consent duration management
+- MSK-100: Non-persistent scope refresh
+- MSK-97: Vendor consent debugging
+- MSK-78: Sample app configuration
+
+**Full Comparison:** [2.0.17...2.1.0](https://github.com/axeptio/axeptio-ios-sdk/compare/2.0.17...2.1.0)


### PR DESCRIPTION
Add comprehensive release notes for version 2.1.0 to the public repository.

This release note includes:
- Overview and key features
- Widget environment configuration
- Consent duration management
- Non-persistent scope support
- Migration guide with code examples
- Installation instructions

Mirrors the release notes from the private repository.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add public release notes for v2.1.0, covering widget environment configuration (production/staging/PR), consent duration controls, and non-persistent scope handling. Includes a migration guide, code examples, and installation steps, mirroring the private repo notes to keep public docs current.

<sup>Written for commit 2583372a24c45cb48c84da9a3ad71e6ded2ccc62. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

