### PR TITLE
docs: clarify widgetType is optional with default .production

### DIFF
--- a/releases/2.1.0.md
+++ b/releases/2.1.0.md
@@ -119,9 +119,7 @@ New data models and APIs for detailed consent inspection.
 
 ### Updating Your Integration
 
-Version 2.1.0 consolidates the initialization API into a single method. Update your initialization code as follows:
-
-**Before (2.0.x):**
+Version 2.1.0 is fully backward compatible. Your existing initialization code will continue to work without changes:
 
 ```swift
 Axeptio.shared.initialize(
@@ -131,14 +129,14 @@ Axeptio.shared.initialize(
 )
 ```
 
-**After (2.1.0):**
+**Optional: To use staging or PR environments:**
 
 ```swift
 Axeptio.shared.initialize(
     targetService: .publisherTcf,
     clientId: "your-client-id",
     cookiesVersion: "your-version",
-    widgetType: .production  // Explicitly specify environment
+    widgetType: .staging  // Optional: .production (default), .staging, or .pr
 )
 ```
 
@@ -146,24 +144,28 @@ Axeptio.shared.initialize(
 
 **Breaking Changes:**
 
-- Previous `initialize()` method overloads have been replaced with a single unified method
-- The `token` parameter is now optional
-- You must specify a `widgetType` (use `.production` for existing production apps)
+- None - this release is fully backward compatible
+
+**New Optional Parameters:**
+
+- `widgetType`: Choose widget environment (`.production` by default, or `.staging`, `.pr`)
+- `token`: Optional authentication token
+- `cookiesDurationDays`: Consent duration (default: 190 days)
+- `shouldUpdateCookiesDuration`: Update duration on each consent (default: false)
+
+**New APIs:**
+
+- `getRemainingDaysForConsent() -> Int?`: Check consent expiration
 
 **Deprecations:**
 
 - None
 
-**New APIs:**
-
-- `getRemainingDaysForConsent() -> Int?`: Check consent expiration
-- New initialization parameters: `widgetType`, `widgetPR`, `cookiesDurationDays`, `shouldUpdateCookiesDuration`
-
 ### Testing Your Migration
 
-1. Update your initialization call to include `widgetType: .production`
-2. Test your integration in production mode
-3. (Optional) Test staging environment before releasing
+1. No code changes required - existing integrations work as-is
+2. (Optional) Add `widgetType: .staging` to test against staging environment
+3. (Optional) Add `widgetType: .pr` with `widgetPR: "123"` to test specific PRs
 4. Verify consent behavior matches expectations
 
 ## Installation


### PR DESCRIPTION
Update release notes 2.1.0 to clarify backward compatibility and optional parameters.

## Changes

- Remove breaking change language
- Clarify version 2.1.0 is fully backward compatible
- Document widgetType as optional with .production default
- Emphasize no code changes required for existing integrations
- Position staging/PR widget environments as optional testing features

## Migration Impact

External developers using production environments don't need to change their code. The widgetType parameter defaults to .production, so existing integrations continue working without modification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarify the 2.1.0 release notes: the SDK is fully backward compatible, and widgetType is optional with a default of .production. Staging and PR environments are documented as optional testing.

- **Migration**
  - No code changes needed for existing integrations.
  - widgetType defaults to .production; optionally use .staging or .pr (with widgetPR) for testing.

<sup>Written for commit f78f6146d8f0ee00061c3f32ca2623cabf09aacd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

