### PR TITLE
docs: add release notes for v2.1.1

### DIFF
--- a/releases/2.1.1.md
+++ b/releases/2.1.1.md
@@ -1,0 +1,128 @@
+# Release 2.1.1
+
+**Release Date:** December 13, 2025
+**Type:** Patch Release
+**GitHub Release:** https://github.com/axeptio/axeptio-ios-sdk/releases/tag/2.1.1
+
+## Overview
+
+Version 2.1.1 is a bug fix release that addresses two critical issues affecting widget behavior: the inability to reopen the consent widget after initial display, and a UI freeze that could occur when dismissing the widget.
+
+## Bug Fixes
+
+### Widget Reopening Fix
+
+**Issue:** Widget fails to reopen when calling `showConsentScreen()` after the initial display.
+
+**Impact:** All customers using the `showConsentScreen()` API to allow users to modify their consent preferences from settings or profile screens.
+
+**Root Cause:** The `loadHiddenView()` method in `AxeptioViewModel.swift` only handled the case where the webView was nil. When the webView already existed and `forceShowConsent=true`, the method returned early without presenting the widget.
+
+**Solution:** Added an else branch to handle the reopening scenario:
+- Reloads the webview with `showConsentManager=true` parameter
+- Presents the widget after a brief delay (0.1s for webview reload)
+- Maintains backward compatibility and respects authorization checks
+
+**Related:** [PR #70](https://github.com/axeptio/axeptio-ios-sdk-sources/pull/70), Linear ENG-10315
+
+### UI Freeze Prevention
+
+**Issue:** UI freezes for 1+ minutes after closing the Axeptio widget on iOS. Users reported that a hidden/invisible Axeptio screen remained blocking the UI.
+
+**Impact:** All customers experiencing the freeze after widget dismissal.
+
+**Root Cause:** Race condition in `hideAndDestroy()`:
+- `hideCMP()` calls `dismiss(animated: true)` (asynchronous)
+- `destroyCMP()` was called immediately (synchronous)
+- WebView was destroyed before dismissal animation completed
+- View hierarchy left in inconsistent state
+
+**Solution:** Added completion handler to ensure cleanup happens after dismissal:
+- `hideAndDestroy()` now accepts an optional completion parameter
+- `hideCMP()` uses UIViewController dismiss completion handler
+- `destroyCMP()` only executes after dismiss animation finishes
+
+**Related:** [PR #71](https://github.com/axeptio/axeptio-ios-sdk-sources/pull/71), Linear MSK-132
+
+## Migration Guide
+
+### Updating Your Integration
+
+Version 2.1.1 is fully backward compatible with 2.1.0. No code changes are required.
+
+Simply update your dependency to version 2.1.1:
+
+**Swift Package Manager:**
+```swift
+.package(url: "https://github.com/axeptio/axeptio-ios-sdk", from: "2.1.1")
+```
+
+**CocoaPods:**
+```ruby
+pod 'AxeptioIOSSDK', '~> 2.1.1'
+```
+
+### Verifying the Fix
+
+**Widget Reopening:**
+1. Open your app and let the consent widget display
+2. Close the widget
+3. Navigate to your settings/profile screen
+4. Call `Axeptio.shared.showConsentScreen()`
+5. Verify the widget reopens immediately
+
+**UI Freeze:**
+1. Open your app and display the consent widget
+2. Close the widget using the close button
+3. Verify no UI freeze occurs
+4. Verify the status bar remains visible
+5. Verify UI is immediately responsive
+
+## Installation
+
+### Swift Package Manager
+
+Update your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/axeptio/axeptio-ios-sdk", from: "2.1.1")
+]
+```
+
+Or update via Xcode:
+
+1. File > Packages > Update to Latest Package Versions
+2. Verify version 2.1.1 is installed
+
+### CocoaPods
+
+Update your `Podfile`:
+
+```ruby
+pod 'AxeptioIOSSDK', '~> 2.1.1'
+```
+
+Then run:
+
+```bash
+pod update AxeptioIOSSDK
+```
+
+## Related Resources
+
+- **Documentation:** [README.md](../README.md)
+- **Sample App:** [sample-app-ios](https://github.com/axeptio/sample-app-ios)
+- **GitHub Release:** [v2.1.1](https://github.com/axeptio/axeptio-ios-sdk/releases/tag/2.1.1)
+- **Issues:** [GitHub Issues](https://github.com/axeptio/axeptio-ios-sdk-sources/issues)
+
+## Technical Details
+
+**Commits:** 6 commits from develop branch
+**Pull Request:** [#72](https://github.com/axeptio/axeptio-ios-sdk-sources/pull/72)
+
+**Related Issues:**
+- MSK-132: UI freeze on widget dismissal
+- MSK-134 / ENG-10315: Widget fails to reopen
+
+**Full Comparison:** [2.1.0...2.1.1](https://github.com/axeptio/axeptio-ios-sdk/compare/2.1.0...2.1.1)


### PR DESCRIPTION
Adds release notes for version 2.1.1 documenting the bug fixes:
- Widget reopening fix (PR #70)
- UI freeze prevention (PR #71)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add release notes for v2.1.1 documenting fixes for widget reopening and the UI freeze after dismissal. Includes a brief update guide and verification steps; links to PRs #70/#71 and Linear ENG-10315/MSK-132 to align with the issues.

<sup>Written for commit c11a734ffa0de255e9a3e53e8befbc3ed6c563eb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

