### PR TITLE
chore: add PR title validation workflow [ENG-11179]

### DIFF
--- a/.github/workflows/validate-pull-request-title.yml
+++ b/.github/workflows/validate-pull-request-title.yml
@@ -1,0 +1,13 @@
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  validate:
+    uses: axeptio/tech-scripts/.github/workflows/validate-pull-request-title.yml@validate-pull-request-title-v1.0.0


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/validate-pull-request-title.yml` using the reusable workflow from `axeptio/tech-scripts`
- Required for ENG-11179 compliance: `master` needs ≥1 required status check on its branch protection rule

## Test plan

- [ ] Workflow runs on this PR and `Validate PR Title / validate` check appears
- [ ] After merge, register the check as required:
  ```bash
  gh api repos/axeptio/axeptio-ios-sdk/branches/master/protection/required_status_checks \
    -X PATCH \
    -f strict=false \
    -f 'contexts[]=Validate PR Title / validate'
  ```
- [ ] Verify with: `gh api repos/axeptio/axeptio-ios-sdk/branches/master/protection/required_status_checks`

🤖 Generated with [Claude Code](https://claude.com/claude-code)