### PR TITLE
docs: add 2.2.0 release notes

### DIFF
--- a/releases/2.2.0.md
+++ b/releases/2.2.0.md
@@ -1,0 +1,212 @@
+# Release 2.2.0
+
+**Release Date:** April 29, 2026
+**Type:** Minor Release (with one breaking change)
+**GitHub Release:** https://github.com/axeptio/axeptio-ios-sdk/releases/tag/2.2.0
+
+## Overview
+
+Version 2.2.0 promotes the `2.2.0-beta.1` pre-release to stable. It introduces a SwiftUI integration layer, removes Objective-C support, hardens consent collection in the Row J/L scenarios (ATT denied + `allowPopupDisplayWithRejectedDeviceTrackingPermissions(true)`), and brings substantial improvements around webview lifecycle, error reporting, and event deduplication.
+
+## ⚠ Breaking Changes
+
+### Objective-C support removed (MSK-121)
+
+The SDK is now **Swift-only**. The following have been removed:
+
+- `Axeptio.h` umbrella header
+- All `@objc` annotations on the public API
+- `NSObject` inheritance from `Axeptio`, `AxeptioEventListener`, `AxeptioServiceHelper`, `GoogleConsentV2`
+- The `sampleObjectiveC/` example app
+
+**Migration for Objective-C apps:** Continue consuming the SDK by writing a thin Swift wrapper that exposes only the entry points your app needs, and import the wrapper into your Obj-C code via a generated bridging header.
+
+## What's New
+
+### SwiftUI integration layer (MSK-158)
+
+A first-class SwiftUI surface, additive to the existing UIKit API:
+
+- `.axeptioConsentScreen()` view modifier
+- `AxeptioObservable` `ObservableObject` wrapper for reactive consent state
+- iOS 15+ deployment target
+
+### Force-show consent debug toggle (MSK-142)
+
+Sample app exposes a debug toggle to force-display the consent screen, simplifying QA of edge-case consent flows.
+
+### Surface error when consent screen display is blocked
+
+When consent collection cannot proceed (e.g. blocked by ATT state), the SDK now surfaces an explicit error instead of failing silently.
+
+### Graceful failure recovery for web widget JS errors (#31)
+
+The SDK's webview now recovers from JavaScript errors in the embedded widget instead of leaving consent collection in a broken state. `console.error` forwarding is kept on in production for telemetry.
+
+## Bug Fixes
+
+### Row J/L consent scenarios (MSK-142)
+
+End-to-end fix for the "Row J" scenario — ATT denied + `allowPopupDisplayWithRejectedDeviceTrackingPermissions(true)` + no consent. Previously the widget would not display in this state. Includes:
+
+- Correct `hasNoConsent` logic for Row J/L
+- Communicate Row J state to the web widget via localStorage
+- Proper webview-load completion in the Row J flow
+- Widget auto-display behavior corrected
+
+### Consent + legitimate-interest combined (MSK-152, #53)
+
+Consent APIs now combine both consent and legitimate-interest grants for vendors, matching the IAB TCF specification.
+
+### Backward compatibility for `widgetType`
+
+Restores 2.0.x default-widget behavior (`widgetType.pr`) so existing integrations are not silently broken when migrating from 2.0.x.
+
+### Webview lifecycle hardening (#89)
+
+- Cancel pending `hideAndDestroy` when the CMP is re-opened (no more ghost destroy after re-display)
+- Cancel an existing `destroyWorkItem` before reassigning, and only guard cancel on re-open
+- Delay `hideAndDestroy` by `cmpDestroyInterval` after cookies-close
+- `cmpDestroyInterval` exposed for tuning
+
+### Rapid consent-saved deduplication
+
+Deduplicate rapid consent-saved events emitted by the webview to avoid downstream double-counting. Dedup state is reset on consent clear; tests are deterministic via injected date provider.
+
+### Consent proof timer
+
+Guards the `consentProofTimer` clear path against stale success callbacks.
+
+### SDK init validation + logging (SUP-592)
+
+Adds validation and structured logging during SDK initialization for clearer error reporting on misconfiguration.
+
+## Migration Guide
+
+### Updating Your Integration
+
+#### Swift apps (most common)
+
+Version 2.2.0 is **source-compatible** with 2.1.x for Swift consumers. Update your dependency:
+
+**Swift Package Manager:**
+```swift
+.package(url: "https://github.com/axeptio/axeptio-ios-sdk", from: "2.2.0")
+```
+
+**CocoaPods:**
+```ruby
+pod 'AxeptioIOSSDK', '~> 2.2.0'
+```
+
+#### Objective-C apps
+
+If your app calls into the SDK from Objective-C, you must add a Swift wrapper. The minimal pattern:
+
+```swift
+// AxeptioBridge.swift
+import AxeptioIOSSDK
+
+@objc public class AxeptioBridge: NSObject {
+    @objc public static func initialize(clientId: String, cookiesVersion: String, token: String?) {
+        Axeptio.shared.initialize(
+            targetService: .brands,
+            clientId: clientId,
+            cookiesVersion: cookiesVersion,
+            token: token
+        )
+    }
+    @objc public static func showConsentScreen() {
+        Axeptio.shared.showConsentScreen()
+    }
+}
+```
+
+Then call `[AxeptioBridge initialize:...]` from your Obj-C code.
+
+#### SwiftUI apps
+
+You can opt into the new SwiftUI layer:
+
+```swift
+import AxeptioIOSSDK
+import SwiftUI
+
+struct RootView: View {
+    @StateObject private var axeptio = AxeptioObservable()
+
+    var body: some View {
+        ContentView()
+            .axeptioConsentScreen()
+    }
+}
+```
+
+The existing UIKit API continues to work unchanged.
+
+## CocoaPods Notice
+
+The CocoaPods Specs Repo will go **read-only on 2026-12-02** (see [the CocoaPods announcement](https://blog.cocoapods.org/CocoaPods-Specs-Repo/)). New SDK versions after that date will be distributed via Swift Package Manager only.
+
+We recommend planning a migration to SPM. Until then:
+
+```ruby
+pod 'AxeptioIOSSDK', '~> 2.2.0'
+```
+
+…will continue to work.
+
+## Verification
+
+After updating, verify:
+
+```bash
+# CocoaPods
+pod trunk info AxeptioIOSSDK | grep 2.2.0
+
+# SPM
+swift package resolve
+```
+
+## Installation
+
+### Swift Package Manager
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/axeptio/axeptio-ios-sdk", from: "2.2.0")
+]
+```
+
+Or in Xcode: **File > Add Package Dependencies…** with URL `https://github.com/axeptio/axeptio-ios-sdk`.
+
+### CocoaPods
+
+```ruby
+pod 'AxeptioIOSSDK', '~> 2.2.0'
+```
+
+```bash
+pod update AxeptioIOSSDK
+```
+
+## Related Resources
+
+- **Documentation:** [README.md](../README.md)
+- **Source repository:** [axeptio/axeptio-ios-sdk-sources](https://github.com/axeptio/axeptio-ios-sdk-sources)
+- **Issues:** [GitHub Issues](https://github.com/axeptio/axeptio-ios-sdk-sources/issues)
+- **CocoaPods deprecation timeline:** [CocoaPods Specs Repo announcement](https://blog.cocoapods.org/CocoaPods-Specs-Repo/)
+
+## Technical Details
+
+**Promoted from:** `2.2.0-beta.1`
+
+**Linear tickets:**
+- MSK-121 — Remove Objective-C support
+- MSK-142 — Row J/L scenario
+- MSK-152 — Combined consent + legitimate interest
+- MSK-158 — SwiftUI integration layer
+- MSK-206 — CocoaPods trunk infrastructure
+- SUP-592 — SDK init validation
+
+**Full comparison:** [2.1.4...2.2.0](https://github.com/axeptio/axeptio-ios-sdk/compare/2.1.4...2.2.0)


### PR DESCRIPTION
## Summary

Adds public-facing release notes for **2.2.0** to `releases/2.2.0.md`.

## What's covered

- **Breaking change** documented: Obj-C support removed (with Swift bridge migration recipe)
- **New features**: SwiftUI integration layer (MSK-158), force-show consent debug toggle (MSK-142), graceful JS error recovery (#31), explicit error when consent display blocked
- **Bug fixes**: Row J/L scenarios (MSK-142), combined consent + legitimate interest (MSK-152, #53), `widgetType` backward compat, webview lifecycle hardening (#89), rapid consent-saved deduplication, consent proof timer guard, SDK init validation (SUP-592)
- **Migration guide** for Swift, Obj-C (via Swift wrapper), and SwiftUI consumers
- **CocoaPods deprecation notice** referencing the 2026-12-02 trunk read-only deadline

## Test plan

- [x] Documentation only — no code changes
- [x] Markdown renders correctly on GitHub

Companion to PR #49 (xcframework). Tracked in beads `ios-dmh`, Linear MSK-206.