### PR TITLE
fix(ci): filter prereleases in deploy_to_cocoapods version detection

### DIFF
--- a/.github/workflows/publish_pods.yml
+++ b/.github/workflows/publish_pods.yml
@@ -33,8 +33,16 @@ jobs:
       - name: Get last pods version
         id: tag
         run: |
-          git fetch --tags 
-          VERSION=$(git tag | sort -V | tail -1)
+          git fetch --tags
+          # Only consider stable semver tags (X.Y.Z). GNU `sort -V` puts
+          # `2.2.0-beta.1` AFTER `2.2.0`, which would mispublish a beta
+          # when promoting to stable. Filter out any tag with a `-` first.
+          # Aligns with RELEASE.md policy: betas are not published to trunk.
+          VERSION=$(git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          if [ -z "$VERSION" ]; then
+            echo "Error: no stable tag (X.Y.Z) found"
+            exit 1
+          fi
           echo "$VERSION"
           echo "LAST_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Deploy to Cocoapods


### PR DESCRIPTION
## Summary

`git tag | sort -V | tail -1` uses GNU version-sort, which treats `2.2.0-beta.1` as **greater** than `2.2.0` (linux extension semantics, opposite of semver). On 2026-04-29 this misfired during the 2.2.0 release: PR #49's auto-triggered run published `2.2.0-beta.1` to trunk instead of `2.2.0`. We had to recover with a manual `pod trunk push` from a maintainer's Mac.

## Fix

Pre-filter to stable semver tags (`X.Y.Z` only) before `sort -V`:

```bash
VERSION=$(git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
```

Verified locally on this repo (with the existing tag set):

| Old logic | New logic |
|---|---|
| `2.2.0-beta.1` ❌ | `2.2.0` ✅ |

## Behavior change

This aligns with the existing policy in [`axeptio-ios-sdk-sources/RELEASE.md`](https://github.com/axeptio/axeptio-ios-sdk-sources/blob/main/RELEASE.md): _"Do NOT publish beta versions to CocoaPods."_

Auto-trigger after PR-merge for a stable release follows this flow:

1. New tag (e.g. `2.2.0`) is created in Step 8 of `RELEASE.md`, **after** the PR merges
2. At workflow time, the new tag does not yet exist → workflow picks the previous stable (e.g. `2.1.4`) → already on trunk → exits cleanly
3. Maintainer runs `gh workflow run deploy_to_cocoapods` after Step 8 to publish the new version

This is the intended flow already; previously it was broken by the `sort -V` issue when prerelease tags existed in repo history.

## Test plan

- [x] Verified locally with current tag set: returns `2.2.0` instead of `2.2.0-beta.1`
- [x] Empty-result guard added (fails fast with clear error if no stable tag)
- [ ] Next stable release (2.2.1 or 2.3.0) confirms the auto-trigger + manual-dispatch flow works end-to-end

## Refs

- beads `ios-tud`
- Follow-up to MSK-206
- Related: `axeptio-ios-sdk-sources` 2.2.0 release retrospective